### PR TITLE
Multi.from can drive multiple subscribers

### DIFF
--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
@@ -545,11 +545,14 @@ public class MultiTest {
         Multi<Integer> multi = Multi.just(1);
         multi.subscribe(subscriber1);
         multi.subscribe(subscriber2);
+
         assertThat(subscriber1.getSubcription(), is(not(nullValue())));
         assertThat(subscriber1.getSubcription(), is(not(EmptySubscription.INSTANCE)));
         assertThat(subscriber1.getLastError(), is(nullValue()));
-        assertThat(subscriber2.getSubcription(), is(EmptySubscription.INSTANCE));
-        assertThat(subscriber2.getLastError(), is(instanceOf(IllegalStateException.class)));
+
+        assertThat(subscriber2.getSubcription(), is(not(nullValue())));
+        assertThat(subscriber2.getSubcription(), is(not(EmptySubscription.INSTANCE)));
+        assertThat(subscriber2.getLastError(), is(nullValue()));
     }
 
     private static class MultiTestSubscriber<T> extends TestSubscriber<T> {


### PR DESCRIPTION
Generally there is reason to limit `Publisher`s to work with only a single `Subscriber`.